### PR TITLE
137196: Add Redmine OpenID plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -q \
  && git clone -b 3.0.2 https://github.com/alphanodes/additionals.git ${REDMINE_PATH}/plugins/additionals \
  && git clone -b v1.1.0 https://github.com/mikitex70/redmine_drawio.git ${REDMINE_PATH}/plugins/redmine_drawio \
  && git clone  https://github.com/eea/redmine_ldap_sync.git ${REDMINE_PATH}/plugins/redmine_ldap_sync \
+ && git clone  https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
  && git clone https://github.com/eea/taskman.redmine.theme.git ${REDMINE_PATH}/public/themes/taskman.redmine.theme \
 #  To be changed when upgraded to a version greater then redmine_crm-4_3_1-pro
  && git clone https://github.com/two-pack/redmine_xls_export.git ${REDMINE_PATH}/plugins/redmine_xls_export \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -q \
  && git clone -b 3.0.2 https://github.com/alphanodes/additionals.git ${REDMINE_PATH}/plugins/additionals \
  && git clone -b v1.1.0 https://github.com/mikitex70/redmine_drawio.git ${REDMINE_PATH}/plugins/redmine_drawio \
  && git clone  https://github.com/eea/redmine_ldap_sync.git ${REDMINE_PATH}/plugins/redmine_ldap_sync \
- && git clone  https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
+ && git clone -b 1.0.0 https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
  && git clone https://github.com/eea/taskman.redmine.theme.git ${REDMINE_PATH}/public/themes/taskman.redmine.theme \
 #  To be changed when upgraded to a version greater then redmine_crm-4_3_1-pro
  && git clone https://github.com/two-pack/redmine_xls_export.git ${REDMINE_PATH}/plugins/redmine_xls_export \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redmine:4.2.1
+FROM redmine:4.2.4
 LABEL maintainer="EEA: IDM2 A-Team <eea-edw-a-team-alerts@googlegroups.com>"
 
 ENV REDMINE_PATH=/usr/src/redmine \
@@ -16,8 +16,8 @@ RUN apt-get update -q \
  && git checkout 62488fa341d21c9b46b27cbb787ee61b46266d0e \
  && cd .. \
  && git clone -b 0.3.4 https://github.com/akiko-pusu/redmine_banner.git ${REDMINE_PATH}/plugins/redmine_banner \
- && git clone -b 3.0.2 https://github.com/alphanodes/additionals.git ${REDMINE_PATH}/plugins/additionals \
- && git clone -b v1.1.0 https://github.com/mikitex70/redmine_drawio.git ${REDMINE_PATH}/plugins/redmine_drawio \
+ && git clone -b 3.0.4 https://github.com/alphanodes/additionals.git ${REDMINE_PATH}/plugins/additionals \
+ && git clone -b v1.3.0 https://github.com/mikitex70/redmine_drawio.git ${REDMINE_PATH}/plugins/redmine_drawio \
  && git clone  https://github.com/eea/redmine_ldap_sync.git ${REDMINE_PATH}/plugins/redmine_ldap_sync \
  && git clone -b 1.0.1 https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
  && git clone https://github.com/eea/taskman.redmine.theme.git ${REDMINE_PATH}/public/themes/taskman.redmine.theme \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -q \
  && git clone -b 3.0.2 https://github.com/alphanodes/additionals.git ${REDMINE_PATH}/plugins/additionals \
  && git clone -b v1.1.0 https://github.com/mikitex70/redmine_drawio.git ${REDMINE_PATH}/plugins/redmine_drawio \
  && git clone  https://github.com/eea/redmine_ldap_sync.git ${REDMINE_PATH}/plugins/redmine_ldap_sync \
- && git clone -b 1.0.0 https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
+ && git clone -b 1.0.1 https://github.com/eea/redmine_openid_connect.git ${REDMINE_PATH}/plugins/redmine_openid_connect \
  && git clone https://github.com/eea/taskman.redmine.theme.git ${REDMINE_PATH}/public/themes/taskman.redmine.theme \
 #  To be changed when upgraded to a version greater then redmine_crm-4_3_1-pro
  && git clone https://github.com/two-pack/redmine_xls_export.git ${REDMINE_PATH}/plugins/redmine_xls_export \

--- a/plugins.cfg
+++ b/plugins.cfg
@@ -1,7 +1,7 @@
-redmine_agile:redmine_agile-1_6_1-pro.zip
-redmine_checklists:redmine_checklists-3_1_19-pro.zip
+redmine_agile:redmine_agile-1_6_2-pro.zip
+redmine_checklists:redmine_checklists-3_1_21-pro.zip
 redmine_contacts_helpdesk:redmine_contacts_helpdesk-4_1_12-pro.zip
 redmine_contacts:redmine_crm-4_3_4-pro.zip
-redmine_reporter:redmine_reporter-2_0_0-pro.zip
-redmine_zenedit:redmine_zenedit-2_0_1-pro.zip
+redmine_reporter:redmine_reporter-2_0_1-pro.zip
+redmine_zenedit:redmine_zenedit-2_0_2-pro.zip
 redmine_resources:redmine_resources-1_0_5-pro.zip


### PR DESCRIPTION
Install the Redmine OpenID plugin.

Note that the automatic configuration of the OpenID plugin is not possible because it depends on the client secret generated within the Keycloak admin interface.