### PR TITLE
fix: UI fixes for Redmine 6.x theme refs #304274

### DIFF
--- a/plugins/zzzz_eea_patches/init.rb
+++ b/plugins/zzzz_eea_patches/init.rb
@@ -20,4 +20,7 @@ EeaPatches::MiniProfilerPatch.configure!
 require_relative 'lib/mini_profiler_authorization_patch'
 EeaPatches::MiniProfilerAuthorizationPatch.apply!
 
+# Add tracker-name-<name> CSS class to issue links for tracker-colored pills.
+require_relative 'lib/issue_tracker_color_patch'
+
 Rails.logger.info '[zzzz_eea_patches] Plugin registered (view overrides + MiniProfiler authorization)'

--- a/plugins/zzzz_eea_patches/lib/issue_tracker_color_patch.rb
+++ b/plugins/zzzz_eea_patches/lib/issue_tracker_color_patch.rb
@@ -1,0 +1,20 @@
+# plugins/zzzz_eea_patches/lib/issue_tracker_color_patch.rb
+#
+# Adds a tracker-name-<parameterized> CSS class to issue links so the theme
+# can render tracker-colored pills (e.g. Bug -> red, Feature -> blue).
+#
+# The core Issue#css_classes method already emits tracker-<id> (e.g. tracker-1),
+# but database IDs are not stable across environments. This patch adds a
+# name-based class (e.g. tracker-name-bug) that survives ID changes.
+
+module IssueTrackerColorPatch
+  def css_classes(user = User.current)
+    s = super
+    return s unless tracker
+    s + " tracker-name-#{tracker.name.parameterize}"
+  end
+end
+
+Rails.application.config.after_initialize do
+  Issue.prepend(IssueTrackerColorPatch) unless Issue.ancestors.include?(IssueTrackerColorPatch)
+end

--- a/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
+++ b/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
@@ -216,6 +216,20 @@ a.issue.tracker-name-support:hover {
   background-color: #b8651b;
 }
 
+/* Status badge on issue detail page. */
+.status.attribute .value {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: #614ba6;
+  color: #fafbfc;
+  font-size: 0.85em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+}
+
 /* #304781: print — keep time-entries table inside the page */
 @media print {
   table.list.time-entries {

--- a/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
+++ b/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
@@ -164,3 +164,41 @@ tr.even.priority-4 td {
 #main-menu .menu-children {
   margin-top: 40px;
 }
+
+/* Tracker-colored pills for issue reference links.
+   The Ruby patch in zzzz_eea_patches adds tracker-name-<name> to issue links.
+   Colors: Bug=red, Feature=blue, Task=purple, Support=orange, default=gray. */
+a.issue[class*="tracker-name-"],
+a.issue[class*="tracker-name-"]:link,
+a.issue[class*="tracker-name-"]:visited,
+a.issue[class*="tracker-name-"]:hover,
+a.issue[class*="tracker-name-"]:active {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  color: #fff !important;
+  font-size: 0.85em;
+  font-weight: 600;
+  text-decoration: none;
+  line-height: 1.4;
+}
+
+a.issue.tracker-name-bug {
+  background-color: #d9534f;
+}
+
+a.issue.tracker-name-feature {
+  background-color: #337ab7;
+}
+
+a.issue.tracker-name-task {
+  background-color: #6f42c1;
+}
+
+a.issue.tracker-name-support {
+  background-color: #e67e22;
+}
+
+a.issue[class*="tracker-name-"]:hover {
+  opacity: 0.85;
+}

--- a/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
+++ b/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
@@ -167,7 +167,8 @@ tr.even.priority-4 td {
 
 /* Tracker-colored pills for issue reference links.
    The Ruby patch in zzzz_eea_patches adds tracker-name-<name> to issue links.
-   Colors: Bug=red, Feature=blue, Task=purple, Support=orange, default=gray. */
+   Colors: Bug=red, Feature=blue, Task=violet, Support=orange, default=gray.
+   Hover colors derived at ~80% of base (matching blue #0065FF -> #0051CC). */
 a.issue[class*="tracker-name-"],
 a.issue[class*="tracker-name-"]:link,
 a.issue[class*="tracker-name-"]:visited,
@@ -176,7 +177,7 @@ a.issue[class*="tracker-name-"]:active {
   display: inline-block;
   padding: 2px 8px;
   border-radius: 10px;
-  color: #fff !important;
+  color: #FAFBFC !important;
   font-size: 0.85em;
   font-weight: 600;
   text-decoration: none;
@@ -184,21 +185,33 @@ a.issue[class*="tracker-name-"]:active {
 }
 
 a.issue.tracker-name-bug {
-  background-color: #d9534f;
+  background-color: #E5123D;
+}
+
+a.issue.tracker-name-bug:hover {
+  background-color: #B70E31;
 }
 
 a.issue.tracker-name-feature {
-  background-color: #337ab7;
+  background-color: #0065FF;
+}
+
+a.issue.tracker-name-feature:hover {
+  background-color: #0051CC;
 }
 
 a.issue.tracker-name-task {
-  background-color: #6f42c1;
+  background-color: #614BA6;
+}
+
+a.issue.tracker-name-task:hover {
+  background-color: #4E3C85;
 }
 
 a.issue.tracker-name-support {
   background-color: #e67e22;
 }
 
-a.issue[class*="tracker-name-"]:hover {
-  opacity: 0.85;
+a.issue.tracker-name-support:hover {
+  background-color: #B8651B;
 }

--- a/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
+++ b/theme_overrides/a1/stylesheets/taskman-backport-overrides.css
@@ -60,7 +60,8 @@ div.wiki table {
   margin-left: 0.2em;
   vertical-align: bottom;
   color: #e5123d;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='10' cy='10' r='9' fill='%23e5123d'/%3E%3Cpath fill='%23fff' d='M7.35 14.35c-.92 0-1.69-.31-2.28-.92-.6-.61-.9-1.37-.9-2.28v-1.8h2.15V6.8c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v2.55h.55V5.8c0-.28.1-.52.3-.72.2-.2.44-.3.72-.3.28 0 .52.1.72.3.2.2.3.44.3.72v3.55h.55V6.25c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v3.1h.55V7.2c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v4.15c0 .84-.3 1.56-.9 2.16-.6.6-1.32.9-2.16.9H7.35z'/%3E%3C/svg%3E") no-repeat center center;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Ccircle cx='10' cy='10' r='9' fill='%23e5123d'/%3E%3Cpath fill='%23fff' d='M7.35 14.35c-.92 0-1.69-.31-2.28-.92-.6-.61-.9-1.37-.9-2.28v-1.8h2.15V6.8c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v2.55h.55V5.8c0-.28.1-.52.3-.72.2-.2.44-.3.72-.3.28 0 .52.1.72.3.2.2.3.44.3.72v3.55h.55V6.25c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v3.1h.55V7.2c0-.27.1-.5.3-.7.2-.2.43-.3.7-.3s.5.1.7.3c.2.2.3.43.3.7v4.15c0 .84-.3 1.56-.9 2.16-.6.6-1.32.9-2.16.9H7.35z'/%3E%3C/svg%3E")
+    no-repeat center center;
   background-size: 20px 20px;
 }
 
@@ -132,4 +133,34 @@ div.wiki table {
 .icon-wiki-page::before {
   content: "\f0f6";
   font-family: FontAwesome;
+}
+
+/* Urgent (priority-4) rows: match Immediate (priority-5) coloring. refs#304274
+   Upstream A1 leaves priority-4 unstyled, so Urgent issues get no row color. */
+tr.odd.priority-4,
+table.list tbody tr.odd.priority-4:hover {
+  color: #900;
+}
+tr.odd.priority-4 {
+  background: #ffc4c4;
+}
+tr.even.priority-4,
+table.list tbody tr.even.priority-4:hover {
+  color: #900;
+}
+tr.even.priority-4 {
+  background: #ffd4d4;
+}
+tr.priority-4 a {
+  color: #900;
+}
+tr.odd.priority-4 td,
+tr.even.priority-4 td {
+  border-color: #ffb4b4;
+}
+
+/* + dropdown usability: bring the menu 2px closer to the + button to close
+   the hover gap. Upstream A1 uses margin-top: 42px. */
+#main-menu .menu-children {
+  margin-top: 40px;
 }


### PR DESCRIPTION
## What changed

Three sets of UI fixes for the A1 theme:

### 1. Print styles and dropdown hover fix
- Generic print CSS for time-entries table: all td cells wrap aggressively, all th cells wrap at word boundaries, rows avoid page breaks
- Fixed + dropdown hover gap: reduced margin-top from 42px to 40px

### 2. Tracker-colored pills
- Ruby patch (IssueTrackerColorPatch) adds tracker-name-<parameterized> CSS class to Issue#css_classes via after_initialize + prepend
- CSS renders colored pills on issue reference links.

### 3. EEA palette colors
- Bug=red #E5123D, Feature=blue #0065FF, Task=violet #614BA6, Support=orange #e67e22
- Text color #FAFBFC
- Hover colors derived at ~80% of base (matching blue #0065FF -> #0051CC)

## Why
- Dropdown hover gap made the + menu unusable
- Tracker-colored pills were lost in Redmine 6.x upgrade; restoring them improves visual scanning of issue lists

## How to verify
1. Build and run the container
2. Check issue lists - each tracker should show a colored pill on reference links
3. Hover over pills - background should darken
4. Hover the + dropdown in the main menu - should stay open